### PR TITLE
Fix Homebrew tap workflow checksum command

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -26,10 +26,10 @@ jobs:
 
           # Compute SHA256 for each architecture
           for f in ./assets/*aarch64*.dmg; do
-            echo "ARM_SHA256=$(shasum -a 256 "$f" | cut -d' ' -f1)" >> "$GITHUB_ENV"
+            echo "ARM_SHA256=$(sha256sum "$f" | cut -d' ' -f1)" >> "$GITHUB_ENV"
           done
           for f in ./assets/*x64*.dmg; do
-            echo "INTEL_SHA256=$(shasum -a 256 "$f" | cut -d' ' -f1)" >> "$GITHUB_ENV"
+            echo "INTEL_SHA256=$(sha256sum "$f" | cut -d' ' -f1)" >> "$GITHUB_ENV"
           done
 
       - name: Checkout homebrew tap


### PR DESCRIPTION
## Summary
- Fix `shasum -a 256` → `sha256sum` in `update-homebrew.yml` (Ubuntu runners don't have `shasum`)
- Updated `HOMEBREW_TAP_TOKEN` PAT with push access to `muxara/homebrew-muxara` (manual step, already done)

Closes #50

## Test plan
- [ ] Trigger a release or re-run the Update Homebrew Tap workflow to verify it pushes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)